### PR TITLE
fix handling of containers with failed scans 

### DIFF
--- a/aggregator/ecr_scan_aggregator.go
+++ b/aggregator/ecr_scan_aggregator.go
@@ -18,14 +18,13 @@ func BatchGetScanResultsByTag(repositories map[string]string, registryId string,
 	for c, v := range repositories {
 		result, err := EcrGetScanResultsByTag(strings.Join([]string{prefix, c}, "/"), v, registryId, l)
 		if err == nil {
-			fmt.Printf("appending result for %s:%s \n", c, v)
 			results[c] = result
 		}
 	}
 	return results, err
 }
 
-func EcrGetScanResultsByTag(repositoryName string, imageTag string, registryId string, l logger.Logger) (findings *ecr.DescribeImageScanFindingsOutput, err error) {
+func EcrGetScanResultsByTag(repositoryName string, imageTag string, registryId string, l logger.Logger) (result *ecr.DescribeImageScanFindingsOutput, err error) {
 	s := session.Must(session.NewSession(&aws.Config{
 		Region: aws.String(region),
 	}))
@@ -34,7 +33,7 @@ func EcrGetScanResultsByTag(repositoryName string, imageTag string, registryId s
 	if err != nil {
 		fmt.Println(err.Error())
 	}
-	result, err := svc.DescribeImageScanFindings(input)
+	result, err = svc.DescribeImageScanFindings(input)
 	if err != nil {
 		if err, ok := err.(awserr.Error); ok {
 			switch err.Code() {
@@ -50,14 +49,14 @@ func EcrGetScanResultsByTag(repositoryName string, imageTag string, registryId s
 				fmt.Println(err.Error())
 			}
 		} else {
-			// Print the error, cast err to awserr.Error to get the Code and
+			// Print the error, cast err to awserr. Error to get the Code and
 			// Message from an error.
-			l.Fatalf("%e is no a recognized Error", err.Error())
+			l.Fatalf("%e is not a recognized Error", err.Error())
 		}
 		return &ecr.DescribeImageScanFindingsOutput{
 			ImageId: input.ImageId,
 			ImageScanStatus: &ecr.ImageScanStatus{
-				Status:      aws.String("failed"),
+				Status:      aws.String("FAILED"),
 				Description: aws.String(err.Error()),
 			},
 		}, err

--- a/reporters/junit.go
+++ b/reporters/junit.go
@@ -96,10 +96,11 @@ func getSeverityCount(index string, severityCounts map[string]*int64) (count int
 
 func hasPassedCutoff(cutoff string, severity string) bool {
 	severityMap := map[string]int{
-		"LOW":      0,
-		"MEDIUM":   1,
-		"HIGH":     2,
-		"CRITICAL": 3,
+		"INFORMATIONAL": -1,
+		"LOW":           0,
+		"MEDIUM":        1,
+		"HIGH":          2,
+		"CRITICAL":      3,
 	}
 	return !(severityMap[severity] >= severityMap[cutoff])
 }


### PR DESCRIPTION
handle case where EcrGetScanResults* targets a container that has a failed
scan which doesn't return an error but returns an object without Results.